### PR TITLE
Update javapeople.yaml to fix JavaChampions

### DIFF
--- a/javapeople.yaml
+++ b/javapeople.yaml
@@ -175,7 +175,7 @@
   github: "jasondlee"
 - name: "Java Champions"
   twitter: "@Java_Champions"
-  fediverse: "@JavaChampions@mastodon.cloud"
+  fediverse: "@JavaChampions@mastodon.social"
 - name: "Jean Bisutti"
   twitter: "@jean_bisutti"
   fediverse: "@jean_bisutti@mastodon.social"


### PR DESCRIPTION
Looks like JavaChampions reside on mastodon.social, not on mastodon.cloud