### PR TITLE
Add validation by URL checking

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -27,6 +27,11 @@
 			<artifactId>j2html</artifactId>
 			<version>1.6.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -28,6 +28,12 @@
 			<version>1.6.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>2.0.3</version>
@@ -40,6 +46,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/generator/src/main/java/org/javabubble/generator/Main.java
+++ b/generator/src/main/java/org/javabubble/generator/Main.java
@@ -12,7 +12,9 @@ public class Main {
 
 	public static void main(String[] args) throws IOException {
 		var bubble = new ModelLoader(Path.of("../javapeople.yaml")).load();
-		ModelValidator.validate(bubble);
+		// TODO add some nice CLI handling, e.g., with picocli
+		boolean validateOnPlatforms = args.length > 0 && args[0].equals("--validate-on-platforms");
+		ModelValidator.validate(bubble, validateOnPlatforms);
 		var output = new FileOutput(Path.of("target/site"));
 		new Site(bubble, output).generate();
 	}

--- a/generator/src/main/java/org/javabubble/generator/Main.java
+++ b/generator/src/main/java/org/javabubble/generator/Main.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.javabubble.generator.model.ModelLoader;
+import org.javabubble.generator.model.ModelValidator;
 import org.javabubble.generator.site.FileOutput;
 import org.javabubble.generator.site.Site;
 
@@ -11,6 +12,7 @@ public class Main {
 
 	public static void main(String[] args) throws IOException {
 		var bubble = new ModelLoader(Path.of("../javapeople.yaml")).load();
+		ModelValidator.validate(bubble);
 		var output = new FileOutput(Path.of("target/site"));
 		new Site(bubble, output).generate();
 	}

--- a/generator/src/main/java/org/javabubble/generator/Main.java
+++ b/generator/src/main/java/org/javabubble/generator/Main.java
@@ -10,7 +10,7 @@ import org.javabubble.generator.site.Site;
 public class Main {
 
 	public static void main(String[] args) throws IOException {
-		var bubble = new ModelLoader(Path.of("../")).load();
+		var bubble = new ModelLoader(Path.of("../javapeople.yaml")).load();
 		var output = new FileOutput(Path.of("target/site"));
 		new Site(bubble, output).generate();
 	}

--- a/generator/src/main/java/org/javabubble/generator/model/ModelLoader.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelLoader.java
@@ -22,9 +22,7 @@ public class ModelLoader {
 	}
 
 	public JavaBubble load() throws IOException {
-		var bubble = new JavaBubble(parseYAML(new TypeReference<List<JavaPerson>>() {
-		}));
-		ModelValidator.validate(bubble);
+		var bubble = new JavaBubble(parseYAML(new TypeReference<List<JavaPerson>>() {}));
 		return bubble;
 	}
 

--- a/generator/src/main/java/org/javabubble/generator/model/ModelLoader.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelLoader.java
@@ -13,23 +13,23 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class ModelLoader {
 
-	private final Path base;
+	private final Path path;
 	private final ObjectMapper mapper;
 
-	public ModelLoader(Path base) {
-		this.base = base;
+	public ModelLoader(Path path) {
+		this.path = path;
 		this.mapper = new ObjectMapper(new YAMLFactory());
 	}
 
 	public JavaBubble load() throws IOException {
-		var bubble = new JavaBubble(parseYAML("javapeople.yaml", new TypeReference<List<JavaPerson>>() {
+		var bubble = new JavaBubble(parseYAML(new TypeReference<List<JavaPerson>>() {
 		}));
 		ModelValidator.validate(bubble);
 		return bubble;
 	}
 
-	private <T> T parseYAML(String file, TypeReference<T> type) throws IOException {
-		try (var in = Files.newBufferedReader(base.resolve(file), UTF_8)) {
+	private <T> T parseYAML(TypeReference<T> type) throws IOException {
+		try (var in = Files.newBufferedReader(path, UTF_8)) {
 			return mapper.readValue(in, type);
 		}
 	}

--- a/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
@@ -117,7 +117,9 @@ class ModelValidator {
                 if (strResponse.statusCode() == 200) {
                     return strResponse;
                 }
-            } catch (IOException | URISyntaxException e) {
+            } catch (IOException e) {
+				LOG.warn("Caught an (expected) IOException, but will probably continue retrying: {}", e, e);
+			} catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             } catch (InterruptedException e) {
 				LOG.error("Interrupted while checking URL '{}': {}", pfUrl, e, e);

--- a/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
@@ -1,17 +1,126 @@
 package org.javabubble.generator.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.text.Collator;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class ModelValidator {
 
-	private static final Pattern TWITTER_PATTERN = Pattern.compile("@[A-Za-z0-9_]+");
-	private static final Pattern FEDIVERSE_PATTERN = Pattern.compile("@[A-Za-z0-9_]+@[a-z0-9\\-]+(\\.[a-z0-9\\-]+)+");
-	private static final Pattern GITHUB_PATTERN = Pattern.compile("[A-Za-z0-9_\\-]+");
+    public enum Validator {
+        FEDIVERSE(Pattern.compile("^@([A-Za-z0-9_]+)@([a-z0-9\\-]+(\\.[a-z0-9\\-]+)+)$"),
+            (Matcher m) ->
+                "https://%s/@%s".formatted(m.group(2), m.group(1)), 3)
+        , GITHUB(Pattern.compile("^([A-Za-z0-9_\\-]+)$"),
+            (Matcher m) -> "https://github.com/%s".formatted(m.group(1)))
+        , TWITTER(Pattern.compile("^@([A-Za-z0-9_]+)$")
+            // Twitter happily returns 200 for any GET request to its web page
+            //                , (Matcher m) -> "https://twitter.com/%s".formatted(m.group(1)), 0
+            // Even some heuristics didn't work so far as the response always contains the failure handler
+            //                , (String body) -> body.contains("input type=\"submit\" value=\"Try again\"")
+            // -> Postpone proper checking of Twitter handles via the "normal" web page OR use the API???
+            // For the time being we assume that the person has a valid Twitter handle
+            )
+        ;
+
+        private static final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .build();
+        private static final Logger LOG = LoggerFactory.getLogger(Validator.class);
+
+        private final Pattern pattern;
+        private final Function<Matcher, String> platformUrl;
+        // Some Platforms are not very reliable, so retry several times if necessary
+        private final int maxRetries;
+        private final Predicate<String> responseBodyIsInvalid;
+
+        Validator(final Pattern pattern) {
+            this(pattern, null, 0, null);
+        }
+
+        Validator(final Pattern pattern, final Function<Matcher, String> platformUrl) {
+            this(pattern, platformUrl, 0, null);
+        }
+
+        Validator(final Pattern pattern, final Function<Matcher, String> platformUrl, final int maxRetries) {
+            this(pattern, platformUrl, maxRetries, null);
+        }
+
+        Validator(final Pattern pattern, final Function<Matcher, String> platformUrl,
+                  final int maxRetries, final Predicate<String> responseBodyIsInvalid) {
+            this.pattern = pattern;
+            this.platformUrl = platformUrl;
+            this.maxRetries = maxRetries;
+            this.responseBodyIsInvalid = responseBodyIsInvalid;
+        }
+
+        public void validate(final String value) {
+            if (value != null) {
+                Matcher matcher = pattern.matcher(value);
+                if (!matcher.matches()) {
+                    throw new IllegalArgumentException("Field %s has unexpected value %s".formatted(name(), value));
+                }
+                if (null != platformUrl) {
+                        HttpResponse<String> strResponse = tryToValidateOnPlatform(matcher);
+                        if (null != responseBodyIsInvalid && responseBodyIsInvalid.test(strResponse.body())) {
+                            throw new IllegalArgumentException("Looks like '%s' does not know '%s'".formatted(name(),
+                                value));
+                        }
+                }
+            }
+        }
+
+        private HttpResponse<String> tryToValidateOnPlatform(Matcher matcher) {
+            String pfUrl = platformUrl.apply(matcher);
+            LOG.debug("Checking '{}' (Connection Timeout: {})", pfUrl,
+                httpClient.connectTimeout().orElse(Duration.ZERO));
+            for (int retry = 0; retry <= maxRetries; retry++) {
+                HttpResponse<String> result = tryToValidateOnPlatform(pfUrl);
+                if (null != result) {
+                    return result;
+                }
+                LOG.warn("Retrying '{}' ({}/{})", pfUrl, retry + 1, maxRetries);
+            }
+            throw new IllegalArgumentException("Cannot access '%s' for URL '%s'".formatted(name(), pfUrl));
+        }
+
+        private static HttpResponse<String> tryToValidateOnPlatform(String pfUrl) {
+            try {
+                URI uri = new URI(pfUrl);
+                HttpRequest request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .GET()
+                    .build();
+                HttpResponse<String> strResponse = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+                if (strResponse.statusCode() == 200) {
+                    return strResponse;
+                }
+            } catch (IOException | URISyntaxException e) {
+                throw new RuntimeException(e);
+            } catch (InterruptedException e) {
+				LOG.error("Interrupted while checking URL '{}': {}", pfUrl, e, e);
+				Thread.currentThread().interrupt();
+			}
+            return null;
+        }
+    }
 
 	private static final Collator COLLATOR = Collator.getInstance(Locale.ENGLISH);
 	private static final Comparator<JavaPerson> ORDER = Comparator.comparing(p -> p.name().split("-|\s"),
@@ -26,22 +135,16 @@ class ModelValidator {
 		people.stream().reduce(ModelValidator::checkOrder);
 	}
 
-	private static void validate(JavaPerson person) {
-		checkNonEmpty("name", person.name());
-		checkPattern("twitter", TWITTER_PATTERN, person.twitter());
-		checkPattern("fediverse", FEDIVERSE_PATTERN, person.fediverse());
-		checkPattern("github", GITHUB_PATTERN, person.github());
-	}
+    private static void validate(JavaPerson person) {
+        checkNonEmpty("name", person.name());
+        Validator.TWITTER.validate(person.twitter());
+        Validator.FEDIVERSE.validate(person.fediverse());
+        Validator.GITHUB.validate(person.github());
+    }
 
 	private static void checkNonEmpty(String field, String value) {
 		if (value == null || value.isBlank()) {
 			throw new IllegalArgumentException("Field %s must not be empty".formatted(field));
-		}
-	}
-
-	private static void checkPattern(String field, Pattern pattern, String value) {
-		if (value != null && !pattern.matcher(value).matches()) {
-			throw new IllegalArgumentException("Field %s hast unexpected value %s".formatted(field, value));
 		}
 	}
 

--- a/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
@@ -20,7 +20,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-class ModelValidator {
+public class ModelValidator {
 
     public enum Validator {
         FEDIVERSE(Pattern.compile("^@([A-Za-z0-9_]+)@([a-z0-9\\-]+(\\.[a-z0-9\\-]+)+)$"),
@@ -133,7 +133,7 @@ class ModelValidator {
 	private static final Comparator<JavaPerson> ORDER = Comparator.comparing(p -> p.name().split("-|\s"),
 			(a1, a2) -> Arrays.compare(a1, a2, COLLATOR));
 
-	static void validate(JavaBubble bubble) {
+	public static void validate(JavaBubble bubble) {
 		validate(bubble.people());
 	}
 

--- a/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
+++ b/generator/src/main/java/org/javabubble/generator/model/ModelValidator.java
@@ -90,12 +90,17 @@ class ModelValidator {
             String pfUrl = platformUrl.apply(matcher);
             LOG.debug("Checking '{}' (Connection Timeout: {})", pfUrl,
                 httpClient.connectTimeout().orElse(Duration.ZERO));
-            for (int retry = 0; retry <= maxRetries; retry++) {
+			int retry = 0;
+            for (;;) {
                 HttpResponse<String> result = tryToValidateOnPlatform(pfUrl);
                 if (null != result) {
                     return result;
                 }
-                LOG.warn("Retrying '{}' ({}/{})", pfUrl, retry + 1, maxRetries);
+				retry++;
+				if (retry > maxRetries) {
+					break;
+				}
+                LOG.warn("Retrying '{}' ({}/{})", pfUrl, retry, maxRetries);
             }
             throw new IllegalArgumentException("Cannot access '%s' for URL '%s'".formatted(name(), pfUrl));
         }

--- a/generator/src/main/resources/simplelogger.properties
+++ b/generator/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug

--- a/generator/src/test/java/org/javabubble/generator/model/ModelLoaderTest.java
+++ b/generator/src/test/java/org/javabubble/generator/model/ModelLoaderTest.java
@@ -1,0 +1,25 @@
+package org.javabubble.generator.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+class ModelLoaderTest {
+
+	@Test
+	@Disabled ("'toot.thoughtworks.com' is on maintenance (now?)")
+	void loadProblematics() throws IOException {
+		ModelLoader modelLoader = new ModelLoader(Path.of ("src/test/resources/javapeople-with-problems.yaml"));
+		var bubble = modelLoader.load();
+		Assertions.assertNotNull(bubble);
+	}
+
+	@Test
+	void loadNonExisting() throws IOException {
+		ModelLoader modelLoader = new ModelLoader(Path.of ("src/test/resources/javapeople-nonexisting.yaml"));
+		Assertions.assertThrows(IllegalArgumentException.class, modelLoader::load);
+	}
+}

--- a/generator/src/test/java/org/javabubble/generator/model/ModelLoaderTest.java
+++ b/generator/src/test/java/org/javabubble/generator/model/ModelLoaderTest.java
@@ -11,15 +11,17 @@ class ModelLoaderTest {
 
 	@Test
 	@Disabled ("'toot.thoughtworks.com' is on maintenance (now?)")
-	void loadProblematics() throws IOException {
+	void validateProblematics() throws IOException {
 		ModelLoader modelLoader = new ModelLoader(Path.of ("src/test/resources/javapeople-with-problems.yaml"));
 		var bubble = modelLoader.load();
+		ModelValidator.validate(bubble, true);
 		Assertions.assertNotNull(bubble);
 	}
 
 	@Test
 	void loadNonExisting() throws IOException {
 		ModelLoader modelLoader = new ModelLoader(Path.of ("src/test/resources/javapeople-nonexisting.yaml"));
-		Assertions.assertThrows(IllegalArgumentException.class, modelLoader::load);
+		var bubble = modelLoader.load();
+		Assertions.assertThrows(IllegalArgumentException.class, () -> ModelValidator.validate(bubble, true));
 	}
 }

--- a/generator/src/test/resources/javapeople-nonexisting.yaml
+++ b/generator/src/test/resources/javapeople-nonexisting.yaml
@@ -1,0 +1,5 @@
+# These handles do not exist - at least not in the fediverse!
+---
+- name: "Julius Caesar"
+  twitter: "@IS_NEVER_CHECKED_YET"
+  fediverse: "@juliuscaesar@aschemann.net"

--- a/generator/src/test/resources/javapeople-with-problems.yaml
+++ b/generator/src/test/resources/javapeople-with-problems.yaml
@@ -1,0 +1,9 @@
+# These handles usually cause some problems :-( Timeouts etc.
+---
+- name: "Martin Fowler"
+  twitter: "@martinfowler"
+  fediverse: "@mfowler@toot.thoughtworks.com"
+- name: "Susanne Braun"
+  twitter: "@susannebraun"
+  fediverse: "@susannebraun@mstdn.social"
+  github: "BraunSusanne"

--- a/javapeople.yaml
+++ b/javapeople.yaml
@@ -95,7 +95,7 @@
   github: "evacchi"
 - name: "Edson Yanaga"
   twitter: "@yanaga"
-  fediverse: "@yanaga@mastodon.social"
+  fediverse: "@yanaga@mastodon.online"
   github: "yanaga"
 - name: "Eric Deandrea"
   twitter: "@edeandrea"


### PR DESCRIPTION
Hi @marchof,

I came across some handles of Fediverse which turned out to be wrong (cf. 106d673).
Maybe this is due to the fact that people are new on Mastodon and are moving around to other servers?
Hopefully this will become more stable in the future.

Nevertheless, I introduced some advanced validation.
I didn't find a nice solution for Twitter so far (wanted to avoid calling the API for now).

Validation might take some time if the list becomes longer.
In particular there are some Fediverse servers which are really slow and need some retries every now and then (mostly the Thoughtworks server).
I have already some idea to handle this by 
* some validation caching which could also be handled on Github (by persisting the cache), 
* parallelise http requests 
but first wanted to check with you if you like the idea in general?

BTW: It would be great if you could at least introduce an `.editorconfig` to make refactoring and code formatting more concise.

Regs
  Gerd