### PR TITLE
Proposing we start adding atproto user data

### DIFF
--- a/javapeople.yaml
+++ b/javapeople.yaml
@@ -438,6 +438,7 @@
   twitter: "joshaustintech"
   fediverse: "josh@joshaustin.xyz"
   github: "joshaustintech"
+  atproto: "@joshaustin.com"
 - name: "Joshua Bloch"
   twitter: "joshbloch"
   fediverse: "joshbloch@mastodon.social"


### PR DESCRIPTION
A number of Java Champions and Java devs are trying out the [Bluesky](https://blueskyweb.xyz/) beta, which is a reference implementation of the [AT Protocol](https://atproto.com/). You can think of this as the Fediverse competitor. I think it is significant enough to propose adding to the list of supported social links, but this is just personal opinion.